### PR TITLE
User timezone

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,8 +21,8 @@ gem 'friendly_id', '~> 5.1.0.beta.1' # for rails 4.2 support
 gem 'gravtastic'
 gem 'high_voltage'
 gem 'jbuilder'
-gem 'local_time'
 gem 'kaminari'
+gem 'rails-timeago'
 gem 'simple_form'
 gem 'unicorn'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,8 +105,6 @@ GEM
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
     kgio (2.9.3)
-    local_time (1.0.1)
-      coffee-rails
     loofah (2.0.1)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -153,6 +151,9 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.1)
       loofah (~> 2.0)
+    rails-timeago (2.11.1)
+      actionpack (>= 3.1)
+      activesupport (>= 3.1)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -243,11 +244,11 @@ DEPENDENCIES
   jbuilder
   jquery-rails
   kaminari
-  local_time
   pg
   pry-rails
   quiet_assets
   rails (= 4.2.0)
+  rails-timeago
   rails_12factor
   rails_layout
   rubocop

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,5 +14,5 @@
 //= require jquery_ujs
 //= require turbolinks
 //= require bootstrap-sprockets
-//= require local_time
+//= require rails-timeago
 //= require_tree .

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,10 +5,16 @@ class ApplicationController < ActionController::Base
 
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  around_action :user_timezone, if: :signed_in?
+
   private
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:sign_up).append [:team_id, :first_name, :last_name]
     devise_parameter_sanitizer.for(:sign_up).append [:first_name, :last_name]
+  end
+
+  def user_timezone(&block)
+    Time.use_zone(current_user.timezone, &block)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,7 @@ class User < ActiveRecord::Base
   validates :last_name, presence: true
   validates :email, presence: true, uniqueness: { scope: :team_id }
   validates :team, presence: true
+  validates :timezone, presence: true, inclusion: { in: ActiveSupport::TimeZone.zones_map(&:name).keys }
 
   scope :sort_by_contributions, -> {
     joins(:hashtags)
@@ -25,6 +26,8 @@ class User < ActiveRecord::Base
       .group("users.id")
       .order("contributions desc")
   }
+
+  before_create { self.timezone ||= Rails.application.config.time_zone }
 
   def self.active(date)
     includes(:statuses)

--- a/app/views/statuses/_status.html.slim
+++ b/app/views/statuses/_status.html.slim
@@ -1,5 +1,5 @@
 p == auto_link_hashtags status.description
-span> = local_time_ago status.created_at
+= timeago_tag status.created_at
 span.like_count> data={ status_id: status.id } = status.likes_count
 .like_form data={ status_id: status.id }
   - if current_user.likes?(status)

--- a/db/migrate/20150210075028_add_timezone_to_users.rb
+++ b/db/migrate/20150210075028_add_timezone_to_users.rb
@@ -1,0 +1,5 @@
+class AddTimezoneToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :timezone, :string, null: false, default: 'UTC'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150127092225) do
+ActiveRecord::Schema.define(version: 20150210075028) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -94,6 +94,7 @@ ActiveRecord::Schema.define(version: 20150127092225) do
     t.inet     "current_sign_in_ip"
     t.inet     "last_sign_in_ip"
     t.integer  "statuses_count",         default: 0,  null: false
+    t.string   "timezone",               default: "UTC", null: false
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
`local_time`은 클라이언트 시간 기준으로 계산하기 때문에 일별 보기에서 시간이 안 맞아보이는 문제가 있었고, 해결방법은:

1. 클라이언트 시간을 서버에서 받아서 처리하거나
2. 유저별 시간대를 설정할 수 있게 하고 모두 서버에서 처리

이 PR은 2번 방법을 구현함